### PR TITLE
Change mastodon.version from 1.0.0-beta-27-SNAPSHOT to 1.0.0-beta-27

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<license.organizationName>Mastodon authors</license.organizationName>
 		<license.copyrightOwners>Tobias Pietzsch, Jean-Yves Tinevez</license.copyrightOwners>
 
-		<mastodon.version>1.0.0-beta-27-SNAPSHOT</mastodon.version>
+		<mastodon.version>1.0.0-beta-27</mastodon.version>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>


### PR DESCRIPTION
The goal of this PR is to reflect the 1.0.0-beta-27 release of the mastodon core and to prepare the 0.4.0 release of the mastodon-ellipsoid-fitting artefact