### PR TITLE
Add online mean/covariance computation to existing mean and covariance demo

### DIFF
--- a/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/Covariance.java
+++ b/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/Covariance.java
@@ -1,0 +1,30 @@
+package org.mastodon.mamut.fitting.demo.onlinemath;
+
+/**
+ * Computes the covariance for two variables using an online algorithm.
+ * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Algorithms for calculating variance</a>
+ */
+public class Covariance
+{
+	private double meanX = 0;
+
+	private double meanY = 0;
+
+	private double c = 0;
+
+	private int n = 0;
+
+	public void addValue( double x, double y )
+	{
+		n++;
+		double dx = x - meanX;
+		meanX += dx / n;
+		meanY += ( y - meanY ) / n;
+		c += dx * ( y - meanY );
+	}
+
+	public double get()
+	{
+		return c / ( n - 1 );
+	}
+}

--- a/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/CovarianceMatrix.java
+++ b/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/CovarianceMatrix.java
@@ -1,0 +1,41 @@
+package org.mastodon.mamut.fitting.demo.onlinemath;
+
+/**
+ * Computes the covariance matrix for a series of coordinates using the online algorithm.
+ * @see <a href="https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Online">Algorithms for calculating variance</a>
+ */
+public class CovarianceMatrix
+{
+	private final Covariance[][] covariances;
+
+	public CovarianceMatrix( int dimensions )
+	{
+		covariances = new Covariance[ dimensions ][ dimensions ];
+	}
+
+	public void addValue( int[] x )
+	{
+		if ( x.length != covariances.length )
+			throw new IllegalArgumentException( "Input vector has wrong dimension." );
+		for ( int i = 0; i < x.length; i++ )
+		{
+			for ( int j = i; j < x.length; j++ )
+			{
+				if ( covariances[ i ][ j ] == null )
+					covariances[ i ][ j ] = new Covariance();
+				covariances[ i ][ j ].addValue( x[ i ], x[ j ] );
+				if ( i != j )
+					covariances[ j ][ i ] = covariances[ i ][ j ];
+			}
+		}
+	}
+
+	public double[][] get()
+	{
+		double[][] result = new double[ covariances.length ][ covariances.length ];
+		for ( int i = 0; i < covariances.length; i++ )
+			for ( int j = 0; j < covariances.length; j++ )
+				result[ i ][ j ] = covariances[ i ][ j ].get();
+		return result;
+	}
+}

--- a/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/Mean.java
+++ b/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/Mean.java
@@ -1,0 +1,19 @@
+package org.mastodon.mamut.fitting.demo.onlinemath;
+
+public class Mean
+{
+	private long sum = 0;
+
+	private int n;
+
+	public void addValue( long x )
+	{
+		n++;
+		sum += x;
+	}
+
+	public double get()
+	{
+		return ( double ) sum / n;
+	}
+}

--- a/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/MeansVector.java
+++ b/src/test/java/org/mastodon/mamut/fitting/demo/onlinemath/MeansVector.java
@@ -1,0 +1,29 @@
+package org.mastodon.mamut.fitting.demo.onlinemath;
+
+public class MeansVector
+{
+	private final Mean[] means;
+
+	public MeansVector( int dimensions )
+	{
+		means = new Mean[ dimensions ];
+	}
+
+	public void addValue( int[] x )
+	{
+		for ( int i = 0; i < x.length; i++ )
+		{
+			if ( means[ i ] == null )
+				means[ i ] = new Mean();
+			means[ i ].addValue( x[ i ] );
+		}
+	}
+
+	public double[] get()
+	{
+		double[] result = new double[ means.length ];
+		for ( int i = 0; i < means.length; i++ )
+			result[ i ] = means[ i ].get();
+		return result;
+	}
+}

--- a/src/test/java/org/mastodon/mamut/fitting/util/DemoUtils.java
+++ b/src/test/java/org/mastodon/mamut/fitting/util/DemoUtils.java
@@ -45,6 +45,7 @@ import org.mastodon.mamut.views.bdv.MamutViewBdv;
 import org.mastodon.model.DefaultSelectionModel;
 import org.mastodon.model.SelectionModel;
 import org.mastodon.views.bdv.SharedBigDataViewerData;
+import org.scijava.Context;
 
 import javax.annotation.Nonnull;
 import java.util.Objects;
@@ -59,7 +60,7 @@ public class DemoUtils
 	public static ProjectModel wrapAsAppModel( final Img< FloatType > image, final Model model )
 	{
 		final SharedBigDataViewerData sharedBigDataViewerData = asSharedBdvDataXyz( image );
-		return ProjectModel.create( null, model, sharedBigDataViewerData, null );
+		return ProjectModel.create( new Context(), model, sharedBigDataViewerData, null );
 	}
 
 	public static MinimalProjectModel wrapAsMinimalModel( final Img< FloatType > image, final Model model )


### PR DESCRIPTION
This PR does the following 3 changes:

- Make ComputeMeanAndVarianceDemo functional again by adding a Context in the wrapAsAppModel method of DemoUtils
- Add computation of online mean and online covariance and compare the results and performance to the existing two-pass solution
- Avoid redundant computations in the two-pass solution to make the performance comparison more realistic